### PR TITLE
Add unit tests and configure pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ AI 기술과 확장 가능한 클라우드 아키텍처를 적용하여, 스크�
 + AI / ML:
     + OCR: pytesseract/Naver Clova OCR (초기), AWS Textract (확장)
     + LLM: OpenAI GPT API (gpt-3.5-turbo, gpt-4)
+## 테스트 실행
+필요한 패키지를 설치하고 Pytest로 단위 테스트를 실행할 수 있습니다.
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ streamlit
 pandas
 boto3
 openai
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Add project root to sys.path so tests can import modules from src
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_ai_utils.py
+++ b/tests/test_ai_utils.py
@@ -1,0 +1,47 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.ai_utils import analyze_text_with_gpt
+
+
+def test_analyze_text_with_gpt_success():
+    result_json = json.dumps({
+        'data_analysis_results': {
+            'content_type': '소셜 미디어',
+            'main_topics': ['topic'],
+            'entities': [],
+            'keywords': []
+        },
+        'creative_profiling_results': {
+            'inferred_user_interests': [],
+            'new_tag_suggestions': [],
+            'profiler_summary': 'summary'
+        }
+    })
+
+    mock_response = SimpleNamespace(
+        choices=[SimpleNamespace(
+            message=SimpleNamespace(
+                tool_calls=[SimpleNamespace(
+                    function=SimpleNamespace(arguments=result_json)
+                )]
+            )
+        )]
+    )
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_response
+
+    mock_st = SimpleNamespace(
+        secrets={'openai': {'api_key': 'key'}},
+        success=lambda msg: None,
+        error=lambda msg: None
+    )
+
+    with patch('src.ai_utils.OpenAI', return_value=mock_client), \
+         patch('src.ai_utils.st', mock_st):
+        result = analyze_text_with_gpt('hello')
+
+    mock_client.chat.completions.create.assert_called_once()
+    assert result['creative_profiling_results']['profiler_summary'] == 'summary'

--- a/tests/test_aws_utils.py
+++ b/tests/test_aws_utils.py
@@ -1,0 +1,36 @@
+import io
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.aws_utils import upload_file_to_s3
+
+
+def test_upload_file_to_s3_success():
+    mock_file = io.BytesIO(b'data')
+    mock_file.name = 'test.png'
+    mock_file.type = 'image/png'
+
+    mock_client = MagicMock()
+    mock_st = SimpleNamespace(
+        secrets={'aws': {
+            'aws_access_key_id': 'id',
+            'aws_secret_access_key': 'secret',
+            'aws_region_name': 'us-east-1',
+            'aws_storage_bucket_name': 'bucket'
+        }},
+        success=lambda msg: None,
+        error=lambda msg: None
+    )
+
+    with patch('src.aws_utils.st', mock_st), \
+         patch('src.aws_utils.get_s3_client', return_value=mock_client), \
+         patch('src.aws_utils.uuid.uuid4', return_value='1234'):
+        url = upload_file_to_s3(mock_file)
+
+    mock_client.upload_fileobj.assert_called_once_with(
+        mock_file,
+        'bucket',
+        'uploads/1234.png',
+        ExtraArgs={'ContentType': 'image/png'}
+    )
+    assert url == 'https://bucket.s3.us-east-1.amazonaws.com/uploads/1234.png'

--- a/tests/test_ocr_utils.py
+++ b/tests/test_ocr_utils.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.ocr_utils import extract_text_with_clova_ocr
+
+
+def test_extract_text_with_clova_ocr_success():
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        'images': [{
+            'fields': [
+                {'inferText': 'Hello'},
+                {'inferText': 'World'}
+            ]
+        }]
+    }
+    mock_response.raise_for_status.return_value = None
+
+    mock_st = SimpleNamespace(
+        secrets={'naver_ocr': {
+            'api_url': 'http://api',
+            'secret_key': 'secret'
+        }},
+        success=lambda msg: None,
+        error=lambda msg: None
+    )
+
+    with patch('src.ocr_utils.st', mock_st), \
+         patch('src.ocr_utils.requests.post', return_value=mock_response) as mock_post:
+        text = extract_text_with_clova_ocr('http://image')
+
+    mock_post.assert_called_once()
+    assert text == 'Hello World'


### PR DESCRIPTION
## Summary
- add mocked tests for S3 uploads, Clova OCR, and GPT analysis
- configure pytest and document test execution

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6d2470f7c83229856781ce3aaff59