### PR TITLE
#8 - Fix/history page stability

### DIFF
--- a/pages/1_history.py
+++ b/pages/1_history.py
@@ -12,9 +12,9 @@ if not history:
 else:
     for i, record in enumerate(history):
         with st.expander(record["filename"], expanded=False):
-            if record.get("analysis_result"):
+            if record.get("objective_result"):
                 st.subheader("GPT 분석 결과")
-                st.json(record["analysis_result"])
+                st.json(record["objective_result"])
             if record.get("extracted_text"):
                 st.subheader("OCR 텍스트")
                 st.text_area(

--- a/pages/1_history.py
+++ b/pages/1_history.py
@@ -10,7 +10,7 @@ history = st.session_state.get("history", [])
 if not history:
     st.info("아직 분석 기록이 없습니다. 메인 페이지에서 이미지를 분석해 주세요.")
 else:
-    for record in history:
+    for i, record in enumerate(history):
         with st.expander(record["filename"], expanded=False):
             if record.get("analysis_result"):
                 st.subheader("GPT 분석 결과")
@@ -21,5 +21,5 @@ else:
                     "텍스트",
                     record["extracted_text"],
                     height=200,
-                    key=f"history_{record['filename']}",
+                    key=f"history_{record['filename']}_{i}",
                 )


### PR DESCRIPTION
#8 
- History 페이지에서 분석 결과가 누락되던 문제(키 불일치)를 수정
- 히스토리 페이지 랜더링시 동일 파일명 다건 존재 시 대비하여 파일명에 인덱스 추가