### PR TITLE
PostgreSQL 적용 전: X-User-Id 기반 유저 분리 규칙 도입

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,8 +6,17 @@ from enum import Enum
 from typing import Any, Optional
 from uuid import uuid4
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends, Header
 from pydantic import BaseModel, Field
+
+
+
+## 유저별 서비스 제공을 위한 기초 셋팅 1
+#유저 식별(데모용)은 헤더의 X-User-Id로 처리, 유저 식별 없이는 401 에러 반환
+def get_current_user(x_user_id: str | None = Header(None, alias="X-User-Id")) -> str:
+    if x_user_id is None or x_user_id.strip() == "":
+        raise HTTPException(status_code=401, detail="Unauthorized: Missing X-User-Id header")
+    return x_user_id.strip()
 
 
 
@@ -48,15 +57,24 @@ app = FastAPI(
 )
 
 
-_jobs: dict[str, JobReadResponse] = {}
+
+## 유저별 서비스 제공을 위한 기초 셋팅 2
+# 유저별로 Job을 분리저장(PostgreSQL 적용 전 임시 in-memory 저장소)
+_jobs_by_user: dict[str, dict[str, JobReadResponse]] = {}
 
 
 @app.post("/v1/jobs", response_model=JobCreateResponse, status_code=201)
-def create_job(payload: Optional[JobCreateRequest] = None) -> JobCreateResponse:
+def create_job(
+    payload: Optional[JobCreateRequest] = None,
+    user_id: str = Depends(get_current_user),
+) -> JobCreateResponse:
     payload = payload or JobCreateRequest()
     now = datetime.now(timezone.utc)
     job_id = str(uuid4())
-    _jobs[job_id] = JobReadResponse(
+
+    # 유저 스코프 저장소가 없으면 만든다.
+    _jobs_by_user.setdefault(user_id, {})
+    _jobs_by_user[user_id][job_id] = JobReadResponse(
         job_id=job_id,
         status=JobStatus.queued,
         created_at=now,
@@ -67,9 +85,15 @@ def create_job(payload: Optional[JobCreateRequest] = None) -> JobCreateResponse:
     return JobCreateResponse(job_id=job_id)
 
 
+
+## 유저별 서비스 제공을 위한 기초 셋팅 3
 @app.get("/v1/jobs/{job_id}", response_model=JobReadResponse)
-def get_job(job_id: str) -> JobReadResponse:
-    job = _jobs.get(job_id)
+def get_job(
+    job_id: str,
+    user_id: str = Depends(get_current_user),
+) -> JobReadResponse:
+    # 같은 job_id라도 유저가 다르면 접근 불가(404)
+    job = _jobs_by_user.get(user_id, {}).get(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
     return job


### PR DESCRIPTION
## 개요

**기간**: 2026.03.15 - 2026.03.15

PostgreSQL로 저장 기능을 붙이기 전에, 먼저 **유저별 서비스를** 하기 위한 API 기본 규칙 구현. 
(기존에는 세션 단위로만 분석) 
이번 PR에서는 요청 헤더의 `X-User-Id` 값을 기준으로 Job을 구분해서 저장/조회.  
(현재는 DB가 아니라 **메모리(in-memory)** 에 임시로 저장.)

---

## 배경

* DB로 저장을 시작한 뒤에 유저별 식별을 추가하면, 기존 데이터/조회 로직을 수정해야 하므로 작업 복잡.
* DB로 넘어가기 전에, 먼저 **“유저별 분리”** 는 규칙을 구현하고 작동 테스트.

---

## 이번 PR에서 달라진 것 (변경 사항)

### 1) `X-User-Id` 헤더를 필수로 받음

* Job 관련 API 요청에서 `X-User-Id` 헤더가 없으면 **401 에러**를 반환

---

### 2) Job을 유저별로 나눠서 저장/조회 (in-memory)

* 같은 API를 써도, `X-User-Id` 값이 다르면 Job에 접근 불가.
* 같은 `job_id`라도 다른 유저로 조회하면 404 에러 발생.

---

## 테스트 (curl)

### 1) 헤더 없이 Job 생성 → 401

```bash
curl -i -X POST "http://127.0.0.1:8000/v1/jobs" \
  -H "Content-Type: application/json" \
  -d '{"source_url":"https://example.com/a.png","metadata":{}}'
```
<img width="2100" height="276" alt="유저식별401" src="https://github.com/user-attachments/assets/26ba0747-b709-42b1-80fc-326ed9b4f6b5" />



### 2) X-User-Id: alice로 Job 생성 → 201 + job_id 반환

```bash
curl -i -X POST "http://127.0.0.1:8000/v1/jobs" \
  -H "X-User-Id: alice" \
  -H "Content-Type: application/json" \
  -d '{"source_url":"https://example.com/a.png","metadata":{}}'
```



### 3) X-User-Id: alice로 Job 생성 → 201 + job_id 반환

```bash
curl -i -X POST "http://127.0.0.1:8000/v1/jobs" \
  -H "X-User-Id: alice" \
  -H "Content-Type: application/json" \
  -d '{"source_url":"https://example.com/a.png","metadata":{}}'
```
<img width="1362" height="438" alt="유저식별201" src="https://github.com/user-attachments/assets/413d084b-7293-448f-b440-62882bf0cdff" />


### 3) alice가 만든 job_id를 X-User-Id: scott으로 조회 → 404

```bash
curl -i "http://127.0.0.1:8000/v1/jobs/b688fdc8-cf6a-4616-b9e1-013568fc07e6"   -H "X-User-Id: scott"
```
<img width="1520" height="326" alt="유저다름404" src="https://github.com/user-attachments/assets/e13ca75c-b51d-4b4f-bceb-2b9a314a4e0c" />


---

## 한계 (이번 PR의 범위)

* 지금은 DB에 저장하는 단계가 아니라, 메모리에만 저장(서버 재시작하면 데이터가 사라짐)
* X-User-Id는 “로그인” 같은 진짜 인증이 아니라, 데모 단계에서 유저를 구분하기 위한 Key



