### PR TITLE
PostgreSQL 전환: Jobs 저장소 DB화 + X-User-Id user scope 제한

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ AI 기술과 확장 가능한 클라우드 아키텍처를 적용하여, 스크�
 ## 2. 아키텍처 설계
 본 시스템은 확장성을 고려하여 3단계의 고도화 과정을 거쳐 개발한다. 각 기능 모듈을 독립적으로 설계하여, 변화하는 요구사항에 유연하게 대응하고 시스템의 안정성과 처리 용량을 점진적으로 확보하는 것을 목표로 한다.
 
-### Phase 1: MVP 구현 (현재 단계)
+### Phase 1: MVP 구현(완료)
 + 목표: 핵심 기능(이미지 업로드 → OCR → LLM 요약)의 기술적 타당성을 신속하게 검증한다.
 
 + 구조: Streamlit 기반의 단일 서버에서 모든 로직을 동기적으로 처리하는 모놀리식 구조를 채택한다. 이 방식은 신속한 개발에 용이하나, 대규모 요청 처리에는 한계가 있다.
 
-### Phase 2: 기능 분리 및 비동기 처리
+### Phase 2: 기능 분리 및 비동기 처리(현재 단계)
 + 목표: UI 서버와 핵심 로직을 분리하여 시스템 안정성 및 확장성을 확보한다.
 
-+ 구조: S3와 Lambda를 이용한 이벤트 기반 비동기 처리 구조를 도입하여 UI 서버의 부하를 최소화한다. 분석 결과는 DynamoDB에 저장하여 빠른 조회를 지원한다.
++ 지향 업로드/UI는 요청만 만들고, 실제 OCR·분석·인덱싱은 Job 단위로 분리된 백엔드가 비동기적으로 수행한다. 상태와 결과는 DB에 누적되어 재시도·관측·확장이 가능해야 하며, 모든 조회/처리는 유저 스코프(tenant) 기준으로 격리된다.
 
 ### Phase 3: 대규모 트래픽 대응
 + 목표: 실제 서비스 수준의 대규모 트래픽을 안정적으로 처리할 수 있는 고가용성 아키텍처를 구현한다.
@@ -26,16 +26,30 @@ AI 기술과 확장 가능한 클라우드 아키텍처를 적용하여, 스크�
 + 구조: 클라이언트가 Pre-signed URL을 통해 S3에 직접 업로드하고, SQS를 통해 요청을 안정적으로 제어하여 시스템 전체의 유연성을 더한다.
 
 ## 3. 적용 기술
++ Backend: FastAPI, SQLAlchemy
++ DB: PostgreSQL (docker-compose)
 + Frontend: Streamlit
-+ Backend: Python
-+ Cloud: AWS (S3, Lambda, SQS)
-+ Database: DynamoDB
-+ AI / ML:
-    + OCR: pytesseract/Naver Clova OCR (초기), AWS Textract (확장)
-    + LLM: OpenAI GPT API (gpt-3.5-turbo, gpt-4)
-
++ OCR/LLM: Naver Clova OCR, OpenAI (현재 Streamlit 결합 상태)
++ Vector: FAISS + OpenAI Embeddings (로컬 파일 기반, 추후 교체 가능 지점)
 
 ## 4. 설치 커맨드
 + pip install -r requirements.txt
 + docker compose up -d
 + python -m scripts.init_db
++ uvicorn app.main:app --reload
+
+## 5. Jobs API 실행 순서
++ docker compose up -d
++ python -m scripts.init_db
++ uvicorn app.main:app --reload
+
+
+## 6. 설계 메모
+- 인덱스 선택 이유  
+  `get_job`의 실제 조회 조건이 `job_id + user_id`이고, 이번 변경의 핵심이 user scope 보호이기 때문에 `(user_id, job_id)` 인덱스를 우선 적용했다. 향후 유저별 목록 조회 API가 추가되면 `(user_id, created_at)` 인덱스는 그 시점에 다시 검토한다.
+
+- 이후 확장 방향
+  이번 PR에서는 Jobs API의 저장소를 Postgres로 전환하고, 생성 시 `queued` 상태만 저장하도록 범위를 제한했다. 이후 worker 도입 시 `queued -> running -> succeeded|failed` 상태머신과 `current_step`, `progress`, `attempt` 연결은 별도 PR에서 확장할 예정이다.
+
+- 에러 코드 표준 초안  
+  에러 코드는 `JOB_401`, `JOB_404`, `OCR_429`, `OCR_500`, `LLM_429`, `LLM_500`처럼 prefix 기반 규칙으로 정리하는 방향을 초안으로 둔다. 이번 PR에서는 핵심 동작 변경(Postgres 전환, user scope 강제)에 집중하고, 에러 코드 필드/포맷 도입은 하지 않고 문서 초안만 남긴다.

--- a/app/database/db.py
+++ b/app/database/db.py
@@ -1,16 +1,43 @@
-# db.py
 import os
+from typing import Generator, Optional
+
+from dotenv import load_dotenv
 from sqlalchemy import create_engine
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
-DATABASE_URL = os.getenv("DATABASE_URL")
-if not DATABASE_URL:
-    raise RuntimeError(
-        "DATABASE_URL is not set. "
-        "Create a .env file (see .env.example) or set DATABASE_URL in your environment."
-    )
+load_dotenv()
 
-engine = create_engine(DATABASE_URL, pool_pre_ping=True)
-SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False)
+_engine = None  # type: Optional[Engine]
 
 Base = declarative_base()
+
+
+def get_database_url() -> Optional[str]:
+    return os.getenv("DATABASE_URL")
+
+
+def get_engine() -> Engine:
+    global _engine
+
+    if _engine is None:
+        database_url = get_database_url()
+        if not database_url:
+            raise RuntimeError(
+                "DATABASE_URL is not set. "
+                "Create a .env file (see .env.example) or set DATABASE_URL in your environment."
+            )
+        _engine = create_engine(database_url, pool_pre_ping=True)
+        SessionLocal.configure(bind=_engine)
+    return _engine
+
+
+def get_db() -> Generator[Session, None, None]:
+    # 환경변수가 늦게 주입돼도 요청 시점에 세션을 열 수 있게 지연 초기화
+    get_engine()
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1,15 +1,23 @@
-# models.py
+import json
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, Integer, Text, DateTime, ForeignKey
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, Text
+
 from app.database.db import Base
+
 
 def utcnow():
     return datetime.now(timezone.utc)
 
+
 class Job(Base):
     __tablename__ = "jobs"
+    __table_args__ = (
+        Index("ix_jobs_user_id_job_id", "user_id", "job_id"),
+    )
 
     job_id = Column(String, primary_key=True)
+    user_id = Column(String, nullable=False)
     status = Column(String, nullable=False)          # queued/running/succeeded/failed
     progress = Column(Integer, nullable=False, default=0)
     current_step = Column(String, nullable=True)     # start/ocr/analysis/indexing
@@ -19,12 +27,17 @@ class Job(Base):
     error_message = Column(Text, nullable=True)
 
     source_url = Column(Text, nullable=True)
-    item_id = Column(String, nullable=True)          # succeeded 시 연결
+    item_id = Column(String, nullable=True)
 
     metadata_json = Column(Text, nullable=False, default="{}")
 
     created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
     updated_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
+
+    def metadata_dict(self):
+        # API 응답에서는 JSON 문자열을 dict로 복원해서 반환한다.
+        return json.loads(self.metadata_json or "{}")
+
 
 class Item(Base):
     __tablename__ = "items"
@@ -35,6 +48,7 @@ class Item(Base):
 
     created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
 
+
 class OCRResult(Base):
     __tablename__ = "ocr_results"
 
@@ -44,6 +58,7 @@ class OCRResult(Base):
 
     created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
 
+
 class AnalysisResult(Base):
     __tablename__ = "analysis_results"
 
@@ -51,6 +66,7 @@ class AnalysisResult(Base):
     objective_json = Column(Text, nullable=False)
 
     created_at = Column(DateTime(timezone=True), nullable=False, default=utcnow)
+
 
 class EmbeddingRef(Base):
     __tablename__ = "embeddings"

--- a/app/main.py
+++ b/app/main.py
@@ -1,23 +1,25 @@
-from dotenv import load_dotenv
-load_dotenv()
-
+import json
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 from uuid import uuid4
 
-from fastapi import FastAPI, HTTPException, Depends, Header
+from dotenv import load_dotenv
+from fastapi import Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.database.db import get_db
+from app.database.models import Job
+
+load_dotenv()
 
 
-
-## 유저별 서비스 제공을 위한 기초 셋팅 1
-#유저 식별(데모용)은 헤더의 X-User-Id로 처리, 유저 식별 없이는 401 에러 반환
-def get_current_user(x_user_id: str | None = Header(None, alias="X-User-Id")) -> str:
+# 유저 식별은 헤더의 X-User-Id로 고정하고, 값이 없으면 401을 반환한다.
+def get_current_user(x_user_id: Optional[str] = Header(None, alias="X-User-Id")) -> str:
     if x_user_id is None or x_user_id.strip() == "":
         raise HTTPException(status_code=401, detail="Unauthorized: Missing X-User-Id header")
     return x_user_id.strip()
-
 
 
 class JobStatus(str, Enum):
@@ -28,11 +30,11 @@ class JobStatus(str, Enum):
 
 
 class JobCreateRequest(BaseModel):
-    source_url: str | None = Field(
+    source_url: Optional[str] = Field(
         default=None,
         description="Optional URL of the uploaded asset to process.",
     )
-    metadata: dict[str, Any] = Field(
+    metadata: Dict[str, Any] = Field(
         default_factory=dict,
         description="Optional metadata attached by the client.",
     )
@@ -48,7 +50,7 @@ class JobReadResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     source_url: Optional[str] = None
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
 app = FastAPI(
@@ -57,48 +59,56 @@ app = FastAPI(
 )
 
 
-
-## 유저별 서비스 제공을 위한 기초 셋팅 2
-# 유저별로 Job을 분리저장(PostgreSQL 적용 전 임시 in-memory 저장소)
-_jobs_by_user: dict[str, dict[str, JobReadResponse]] = {}
-
-
 @app.post("/v1/jobs", response_model=JobCreateResponse, status_code=201)
 def create_job(
     payload: Optional[JobCreateRequest] = None,
     user_id: str = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ) -> JobCreateResponse:
     payload = payload or JobCreateRequest()
     now = datetime.now(timezone.utc)
     job_id = str(uuid4())
 
-    # 유저 스코프 저장소가 없으면 만든다.
-    _jobs_by_user.setdefault(user_id, {})
-    _jobs_by_user[user_id][job_id] = JobReadResponse(
+    # 이번 PR에서는 queued 상태만 저장하고, user_id 스코프를 함께 고정한다.
+    job = Job(
         job_id=job_id,
-        status=JobStatus.queued,
+        user_id=user_id,
+        status=JobStatus.queued.value,
+        progress=0,
+        current_step=None,
+        attempt=0,
         created_at=now,
         updated_at=now,
         source_url=payload.source_url,
-        metadata=payload.metadata,
+        metadata_json=json.dumps(payload.metadata),
     )
+    db.add(job)
+    db.commit()
+
     return JobCreateResponse(job_id=job_id)
 
 
-
-## 유저별 서비스 제공을 위한 기초 셋팅 3
 @app.get("/v1/jobs/{job_id}", response_model=JobReadResponse)
 def get_job(
     job_id: str,
     user_id: str = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ) -> JobReadResponse:
-    # 같은 job_id라도 유저가 다르면 접근 불가(404)
-    job = _jobs_by_user.get(user_id, {}).get(job_id)
+    # 같은 job_id라도 user_id가 다르면 404가 되도록 조회 조건을 강제한다.
+    job = db.query(Job).filter(Job.job_id == job_id, Job.user_id == user_id).first()
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
-    return job
+
+    return JobReadResponse(
+        job_id=job.job_id,
+        status=job.status,
+        created_at=job.created_at,
+        updated_at=job.updated_at,
+        source_url=job.source_url,
+        metadata=job.metadata_dict(),
+    )
 
 
 @app.get("/health")
-def health() -> dict[str, bool]:
+def health() -> Dict[str, bool]:
     return {"ok": True}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,18 @@ services:
   postgres:
     image: postgres:16
     container_name: intria-postgres
+    env_file:
+      - .env
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER:-intria}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-example_password}
+      POSTGRES_DB: ${POSTGRES_DB:-intria_db}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - intria_pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,8 +1,29 @@
 from dotenv import load_dotenv
+from sqlalchemy import inspect, text
+
+from app.database.db import Base, get_engine
+
 load_dotenv()
 
-from app.database.db import engine, Base
-import app.database.models  # noqa: F401  모델 로드가 필요
+import app.database.models  # noqa: F401
 
+engine = get_engine()
 Base.metadata.create_all(bind=engine)
+
+inspector = inspect(engine)
+job_columns = {column["name"] for column in inspector.get_columns("jobs")}
+
+with engine.begin() as connection:
+    # 기존 테이블이 있어도 이번 PR에 필요한 user_id 컬럼을 보장한다.
+    if "user_id" not in job_columns:
+        connection.execute(
+            text("ALTER TABLE jobs ADD COLUMN user_id VARCHAR DEFAULT 'system' NOT NULL")
+        )
+
+    index_names = {index["name"] for index in inspector.get_indexes("jobs")}
+    if "ix_jobs_user_id_job_id" not in index_names:
+        connection.execute(
+            text("CREATE INDEX ix_jobs_user_id_job_id ON jobs (user_id, job_id)")
+        )
+
 print("DB tables created")


### PR DESCRIPTION
## 개요

**기간**: 2026.03.15 - 2026.03.15

- Jobs API의 저장소를 기존 in-memory dict 에서 PostgreSQL 로 전환 
- 요청 헤더의 `X-User-Id` 값을 기준으로 유저 스코프(user scope) 정리
- Job 생성/조회의 저장소를 DB로 이동
- 유저별 분리 규칙을 DB 조회 조건에 반영

---


## 이번 PR에서 달라진 것 (변경 사항)

### 1) Jobs 저장소를 in-memory에서 PostgreSQL로 전환

* `create_job` 호출 시 Job row를 DB에 저장
* 이번 PR에서는 `status=queued` 만 저장

---

### 2) `X-User-Id` 헤더를 기준으로 user scope 강제

* 유저 식별 헤더는 `X-User-Id` 로 고정
* Job 관련 API 요청에서 `X-User-Id` 헤더가 없으면 401 을 반환
* `create_job` 시 헤더의 `X-User-Id` 값을 Job row에 저장
* `get_job` 은 `job_id AND user_id` 조건으로만 조회
* 같은 `job_id` 라도 다른 유저가 조회하면 404 를 반환

---

### 3) `jobs` 테이블에 `user_id` 컬럼 및 인덱스 추가

* `jobs.user_id` 컬럼을 `NOT NULL` 로 추가
* 인덱스 `ix_jobs_user_id_job_id (user_id, job_id)` 를 추가

인덱스 선택 이유:
`get_job` 의 실제 조회 조건이 `job_id + user_id` 이고, 이번 변경의 핵심이 user scope 보호이기 때문에 `(user_id, job_id)` 인덱스를 우선 적용한다.
향후 유저별 목록 조회 API가 추가되면 `(user_id, created_at)` 인덱스는 그 시점에 다시 검토할 예정

---

### 4) DB 초기화/실행 흐름 정리

실행 순서:
1. `docker compose up -d postgres`
2. `python -m scripts.init_db`
3. `python -m uvicorn app.main:app --reload --host 127.0.0.1 --port 8000`

---

## 테스트

### 1) 헤더 없이 Job 생성 -> 401
예상응답
```
{
  "detail": "Unauthorized: Missing X-User-Id header"
}
```
<img width="1494" height="680" alt="401_Postman" src="https://github.com/user-attachments/assets/296a32ad-13ba-4133-a8df-c4231fe2d086" />



### 2) X-User-Id: alice 로 Job 생성 -> 201 + job_id
예상응답
```
{
  "job_id": "sample-generated-job-id"
}
```
<img width="1510" height="642" alt="201_Postman" src="https://github.com/user-attachments/assets/7c7301ff-9c38-4150-91ac-704328f80b2a" />



### 3) alice 가 만든 job_id 를 X-User-Id: scott 으로 조회 -> 404
예상응답
```
{
  "detail": "Job not found"
}
```
<img width="1494" height="696" alt="404_Postman" src="https://github.com/user-attachments/assets/5366826b-83c2-4817-a661-d7edd79421a8" />


### 4) DB 스키마 확인
```
docker exec intria-postgres psql -U intria -d intria_db -c "\d jobs"
```
<img width="1518" height="856" alt="jobs_table_desc" src="https://github.com/user-attachments/assets/9eb6aa88-d8cc-4284-8f01-d1a0bb1b3b9e" />

확인 포인트:
user_id 컬럼이 NOT NULL
ix_jobs_user_id_job_id 인덱스 존재





### 5) DB row 저장 확인
```
docker exec intria-postgres psql -U intria -d intria_db -c "SELECT job_id, user_id, status, created_at FROM jobs ORDER BY created_at DESC;"
```
<img width="1580" height="232" alt="db_job_creation" src="https://github.com/user-attachments/assets/51f7d307-83eb-4196-9077-d6366fd4837a" />

확인 포인트:
생성한 Job row가 실제로 저장됨
user_id=alice
status=queued


---

## 한계 (이번 PR의 범위)
- 이번 PR은 Job 생성/조회 저장소를 Postgres로 옮기는 단계까지만 포함한다. 따라서 job의 상태머신, retry, step/progress 업데이트는 현재 미구현

- Streamlit 업로드/분석 UI는 아직 FastAPI Jobs API와의 연결 미구현

- X-User-Id 는 현재 로그인/인증 체계가 아니라, 데모 단계에서 단순 식별을 위한 헤더 값